### PR TITLE
docs: Fix minor typos

### DIFF
--- a/checklist/README.md
+++ b/checklist/README.md
@@ -1,10 +1,10 @@
 # Onboarding Checklist
-- If you were selected and if you were not invited to Slack. Please email us at university@hackerbay,io
-- When you've joined HackerBAy University Slack. Make sure you:
+- If you were selected and have not been invited to Slack, please email us at university@hackerbay.io
+- When you've joined Hackerbay University Slack, make sure you:
   - Upload your real profile picture.
-  - Download Slack Apps for Mobile, and Desktop and sign in there, 
-- You will be paired with your mentor. If you're not paired yet - Please email university@hackerbay.io or talk to `Kumar Abhishek` on Slack. 
-- `Kumar Abhishek` is admin on Slack. He is also managing this program. If there are any feedback / issues. Please do let him know. 
+  - Download Slack Apps for Mobile, and Desktop and sign in there. 
+- You will be paired with a mentor. If you're not paired yet, please email university@hackerbay.io or talk to `Kumar Abhishek` on Slack. 
+- `Kumar Abhishek` is the admin on Slack. He is also managing this program. If there are any feedback / issues, please do let him know. 
 
-.. and that's quite about it! Welcome aboard, and let's partner up in helping you grow. 
-  
+... and that's quite about it! Welcome aboard, and let's partner up in helping you grow. 
+


### PR DESCRIPTION
Modified email address from "university@hackerbay,io" to university@hackerbay.io
Fixed minor typos (E.g HackerBAy to Hackerbay).
Modified some punctuation marks for easier reading.